### PR TITLE
ims #259686, ims #255646 update definitions

### DIFF
--- a/workload/CronJob.json
+++ b/workload/CronJob.json
@@ -4314,7 +4314,7 @@
                               }
                             ]
                           },
-                          "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.",
+                          "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/688-pod-overhead/README.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.",
                           "type": "object"
                         },
                         "preemptionPolicy": {
@@ -4331,7 +4331,7 @@
                           "type": "string"
                         },
                         "readinessGates": {
-                          "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md",
+                          "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/580-pod-readiness-gates/README.md",
                           "items": {
                             "description": "PodReadinessGate contains the reference to a pod condition",
                             "properties": {
@@ -4352,7 +4352,7 @@
                           "type": "string"
                         },
                         "runtimeClassName": {
-                          "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.",
+                          "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/585-runtime-class/README.md This is a beta feature as of Kubernetes v1.14.",
                           "type": "string"
                         },
                         "schedulerName": {

--- a/workload/DaemonSet.json
+++ b/workload/DaemonSet.json
@@ -4168,7 +4168,7 @@
                       }
                     ]
                   },
-                  "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.",
+                  "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/688-pod-overhead/README.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.",
                   "type": "object"
                 },
                 "preemptionPolicy": {
@@ -4185,7 +4185,7 @@
                   "type": "string"
                 },
                 "readinessGates": {
-                  "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md",
+                  "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/580-pod-readiness-gates/README.md",
                   "items": {
                     "description": "PodReadinessGate contains the reference to a pod condition",
                     "properties": {
@@ -4206,7 +4206,7 @@
                   "type": "string"
                 },
                 "runtimeClassName": {
-                  "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.",
+                  "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/585-runtime-class/README.md This is a beta feature as of Kubernetes v1.14.",
                   "type": "string"
                 },
                 "schedulerName": {

--- a/workload/Deployment.json
+++ b/workload/Deployment.json
@@ -4221,7 +4221,7 @@
                       }
                     ]
                   },
-                  "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.",
+                  "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/688-pod-overhead/README.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.",
                   "type": "object"
                 },
                 "preemptionPolicy": {
@@ -4238,7 +4238,7 @@
                   "type": "string"
                 },
                 "readinessGates": {
-                  "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md",
+                  "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/580-pod-readiness-gates/README.md",
                   "items": {
                     "description": "PodReadinessGate contains the reference to a pod condition",
                     "properties": {
@@ -4259,7 +4259,7 @@
                   "type": "string"
                 },
                 "runtimeClassName": {
-                  "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.",
+                  "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/585-runtime-class/README.md This is a beta feature as of Kubernetes v1.14.",
                   "type": "string"
                 },
                 "schedulerName": {

--- a/workload/Job.json
+++ b/workload/Job.json
@@ -4182,7 +4182,7 @@
                       }
                     ]
                   },
-                  "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.",
+                  "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/688-pod-overhead/README.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.",
                   "type": "object"
                 },
                 "preemptionPolicy": {
@@ -4199,7 +4199,7 @@
                   "type": "string"
                 },
                 "readinessGates": {
-                  "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md",
+                  "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/580-pod-readiness-gates/README.md",
                   "items": {
                     "description": "PodReadinessGate contains the reference to a pod condition",
                     "properties": {
@@ -4220,7 +4220,7 @@
                   "type": "string"
                 },
                 "runtimeClassName": {
-                  "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.",
+                  "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/585-runtime-class/README.md This is a beta feature as of Kubernetes v1.14.",
                   "type": "string"
                 },
                 "schedulerName": {

--- a/workload/Pod.json
+++ b/workload/Pod.json
@@ -3991,7 +3991,7 @@
               }
             ]
           },
-          "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.",
+          "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/688-pod-overhead/README.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.",
           "type": "object"
         },
         "preemptionPolicy": {
@@ -4008,7 +4008,7 @@
           "type": "string"
         },
         "readinessGates": {
-          "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md",
+          "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/580-pod-readiness-gates/README.md",
           "items": {
             "description": "PodReadinessGate contains the reference to a pod condition",
             "properties": {
@@ -4029,7 +4029,7 @@
           "type": "string"
         },
         "runtimeClassName": {
-          "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.",
+          "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/585-runtime-class/README.md This is a beta feature as of Kubernetes v1.14.",
           "type": "string"
         },
         "schedulerName": {

--- a/workload/PodSecurityPolicy.json
+++ b/workload/PodSecurityPolicy.json
@@ -265,9 +265,22 @@
             },
             "rule": {
               "description": "rule is the strategy that will dictate what FSGroup is used in the SecurityContext.",
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "MustRunAs",
+                "MayRunAs",
+                "RunAsAny"
+              ],
+              "enumNames": [
+                "MustRunAs",
+                "MayRunAs",
+                "RunAsAny"
+              ]
             }
           },
+          "required": [
+            "rule"
+          ],
           "type": "object"
         },
         "hostIPC": {
@@ -350,7 +363,17 @@
             },
             "rule": {
               "description": "rule is the strategy that will dictate the allowable RunAsGroup values that may be set.",
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "MustRunAs",
+                "MayRunAs",
+                "RunAsAny"
+              ],
+              "enumNames": [
+                "MustRunAs",
+                "MayRunAs",
+                "RunAsAny"
+              ]
             }
           },
           "required": [
@@ -387,7 +410,17 @@
             },
             "rule": {
               "description": "rule is the strategy that will dictate the allowable RunAsUser values that may be set.",
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "MustRunAs",
+                "MustRunAsNonRoot",
+                "RunAsAny"
+              ],
+              "enumNames": [
+                "MustRunAs",
+                "MustRunAsNonRoot",
+                "RunAsAny"
+              ]
             }
           },
           "required": [
@@ -420,7 +453,15 @@
           "properties": {
             "rule": {
               "description": "rule is the strategy that will dictate the allowable labels that may be set.",
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "MustRunAs",
+                "RunAsAny"
+              ],
+              "enumNames": [
+                "MustRunAs",
+                "RunAsAny"
+              ]
             },
             "seLinuxOptions": {
               "description": "seLinuxOptions required to run as; required for MustRunAs More info: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
@@ -479,9 +520,22 @@
             },
             "rule": {
               "description": "rule is the strategy that will dictate what supplemental groups is used in the SecurityContext.",
-              "type": "string"
+              "type": "string",
+              "enum": [
+                "MustRunAs",
+                "MayRunAs",
+                "RunAsAny"
+              ],
+              "enumNames": [
+                "MustRunAs",
+                "MayRunAs",
+                "RunAsAny"
+              ]
             }
           },
+          "required": [
+            "rule"
+          ],
           "type": "object"
         },
         "volumes": {

--- a/workload/ReplicaSet.json
+++ b/workload/ReplicaSet.json
@@ -4168,7 +4168,7 @@
                       }
                     ]
                   },
-                  "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.",
+                  "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/688-pod-overhead/README.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.",
                   "type": "object"
                 },
                 "preemptionPolicy": {
@@ -4185,7 +4185,7 @@
                   "type": "string"
                 },
                 "readinessGates": {
-                  "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md",
+                  "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/580-pod-readiness-gates/README.md",
                   "items": {
                     "description": "PodReadinessGate contains the reference to a pod condition",
                     "properties": {
@@ -4206,7 +4206,7 @@
                   "type": "string"
                 },
                 "runtimeClassName": {
-                  "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.",
+                  "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/585-runtime-class/README.md This is a beta feature as of Kubernetes v1.14.",
                   "type": "string"
                 },
                 "schedulerName": {

--- a/workload/StatefulSet.json
+++ b/workload/StatefulSet.json
@@ -4176,7 +4176,7 @@
                       }
                     ]
                   },
-                  "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.",
+                  "description": "Overhead represents the resource overhead associated with running a pod for a given RuntimeClass. This field will be autopopulated at admission time by the RuntimeClass admission controller. If the RuntimeClass admission controller is enabled, overhead must not be set in Pod create requests. The RuntimeClass admission controller will reject Pod create requests which have the overhead already set. If RuntimeClass is configured and selected in the PodSpec, Overhead will be set to the value defined in the corresponding RuntimeClass, otherwise it will remain unset and treated as zero. More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/688-pod-overhead/README.md This field is alpha-level as of Kubernetes v1.16, and is only honored by servers that enable the PodOverhead feature.",
                   "type": "object"
                 },
                 "preemptionPolicy": {
@@ -4193,7 +4193,7 @@
                   "type": "string"
                 },
                 "readinessGates": {
-                  "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md",
+                  "description": "If specified, all readiness gates will be evaluated for pod readiness. A pod is ready when all its containers are ready AND all conditions specified in the readiness gates have status equal to \"True\" More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/580-pod-readiness-gates/README.md",
                   "items": {
                     "description": "PodReadinessGate contains the reference to a pod condition",
                     "properties": {
@@ -4214,7 +4214,7 @@
                   "type": "string"
                 },
                 "runtimeClassName": {
-                  "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md This is a beta feature as of Kubernetes v1.14.",
+                  "description": "RuntimeClassName refers to a RuntimeClass object in the node.k8s.io group, which should be used to run this pod.  If no RuntimeClass resource matches the named class, the pod will not be run. If unset or empty, the \"legacy\" RuntimeClass will be used, which is an implicit class with an empty definition that uses the default runtime handler. More info: https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/585-runtime-class/README.md This is a beta feature as of Kubernetes v1.14.",
                   "type": "string"
                 },
                 "schedulerName": {

--- a/workload/UPDATE-HISTORY.md
+++ b/workload/UPDATE-HISTORY.md
@@ -1,0 +1,55 @@
+## UPDATE HISTORY for json-schema generated files
+
+- [Pod] deprecated된 serviceAccount 필드 제거 - IMS #256034
+- [HPA] 기존 v2beta1에서 v2beta2로 변경
+- [Pod] "io.k8s.api.core.v1.Container" definition에서 image 필드를 required에 추가
+- [Pod] "io.k8s.api.core.v1.ResourceRequirements" 에 cpu, memory를 properties로 추가 (테스트 필요)
+- [Definitions] ObjectMeta field의 read only 항목 제거 - IMS #256034-action 1586164 - commit 7e8217c
+- [Definitions] delete cluster field of ObjectMeta field - IMS #256034-action 1589321 - commit 2aff73e
+- [Definitions] update descriptions outdated url links - IMS #259686 - commit ea843d3d
+    <details>
+    <summary>변경사항 Detail</summary>
+    
+    - update PodSpec.readinessGates description url
+        - from : https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md
+        - to : https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/580-pod-readiness-gates/README.md
+
+    - update PodSpec.runtimeClassName description url
+        - from : https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
+        - to : https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/585-runtime-class/README.md
+
+    - update "io.k8s.api.node.v1beta1.RuntimeClass", "io.k8s.api.node.v1alpha1.RuntimeClass" description url
+        - from : https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md 
+        - to : https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/585-runtime-class/README.md
+
+    - update PodSpec.overhead description url
+        - from : https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
+        - to : https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/688-pod-overhead/README.md
+
+    - update io.k8s.api.node.v1alpha1.RuntimeClassSpec.overhead, io.k8s.api.node.v1beta1.RuntimeClass.overhead description url
+        - from : https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md 
+        - to : https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/688-pod-overhead/README.md
+    </details>
+- [Definitions] PSP required 필드 추가 및 rule enum 추가  - IMS #255646
+    <details>
+    <summary>변경사항 Detail</summary>
+
+    - "io.k8s.api.policy.v1beta1.PodSecurityPolicySpec".seLinux : "#/definitions/io.k8s.api.policy.v1beta1.SELinuxStrategyOptions" 
+        - add rule enums
+    
+    - "io.k8s.api.policy.v1beta1.PodSecurityPolicySpec".fsGroup : "#/definitions/io.k8s.api.policy.v1beta1.FSGroupStrategyOptions"
+        - add required - 'rule' field
+
+    - "io.k8s.api.policy.v1beta1.PodSecurityPolicySpec".supplementalGroups : "#/definitions/io.k8s.api.policy.v1beta1.SupplementalGroupsStrategyOptions"
+        - add required - 'rule' field
+        - add rule enums
+
+    - "io.k8s.api.policy.v1beta1.PodSecurityPolicySpec".runAsGroup : "#/definitions/io.k8s.api.policy.v1beta1.RunAsGroupStrategyOptions"
+        - add rule enums
+
+    - "io.k8s.api.policy.v1beta1.PodSecurityPolicySpec".runAsUser : "#/definitions/io.k8s.api.policy.v1beta1.RunAsUserStrategyOptions"
+        - add rule enums
+
+    - "io.k8s.api.policy.v1beta1.PodSecurityPolicySpec".fsGroup : "#/definitions/io.k8s.api.policy.v1beta1.FSGroupStrategyOptions"
+        - add rule enums
+    </details>


### PR DESCRIPTION
- [Definitions] update descriptions outdated url links - IMS #259686 - commit ea843d3d
    <details>
    <summary>변경사항 Detail</summary>
    
    - update PodSpec.readinessGates description url
        - from : https://git.k8s.io/enhancements/keps/sig-network/0007-pod-ready%2B%2B.md
        - to : https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/580-pod-readiness-gates/README.md

    - update PodSpec.runtimeClassName description url
        - from : https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md
        - to : https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/585-runtime-class/README.md

    - update "io.k8s.api.node.v1beta1.RuntimeClass", "io.k8s.api.node.v1alpha1.RuntimeClass" description url
        - from : https://git.k8s.io/enhancements/keps/sig-node/runtime-class.md 
        - to : https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/585-runtime-class/README.md

    - update PodSpec.overhead description url
        - from : https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md
        - to : https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/688-pod-overhead/README.md

    - update io.k8s.api.node.v1alpha1.RuntimeClassSpec.overhead, io.k8s.api.node.v1beta1.RuntimeClass.overhead description url
        - from : https://git.k8s.io/enhancements/keps/sig-node/20190226-pod-overhead.md 
        - to : https://github.com/kubernetes/enhancements/blob/master/keps/sig-node/688-pod-overhead/README.md
    </details>
- [Definitions] PSP required 필드 추가 및 rule enum 추가  - IMS #255646
    <details>
    <summary>변경사항 Detail</summary>

    - "io.k8s.api.policy.v1beta1.PodSecurityPolicySpec".seLinux : "#/definitions/io.k8s.api.policy.v1beta1.SELinuxStrategyOptions" 
        - add rule enums
    
    - "io.k8s.api.policy.v1beta1.PodSecurityPolicySpec".fsGroup : "#/definitions/io.k8s.api.policy.v1beta1.FSGroupStrategyOptions"
        - add required - 'rule' field

    - "io.k8s.api.policy.v1beta1.PodSecurityPolicySpec".supplementalGroups : "#/definitions/io.k8s.api.policy.v1beta1.SupplementalGroupsStrategyOptions"
        - add required - 'rule' field
        - add rule enums

    - "io.k8s.api.policy.v1beta1.PodSecurityPolicySpec".runAsGroup : "#/definitions/io.k8s.api.policy.v1beta1.RunAsGroupStrategyOptions"
        - add rule enums

    - "io.k8s.api.policy.v1beta1.PodSecurityPolicySpec".runAsUser : "#/definitions/io.k8s.api.policy.v1beta1.RunAsUserStrategyOptions"
        - add rule enums

    - "io.k8s.api.policy.v1beta1.PodSecurityPolicySpec".fsGroup : "#/definitions/io.k8s.api.policy.v1beta1.FSGroupStrategyOptions"
        - add rule enums
    </details>